### PR TITLE
Consumer Proguard Rules added

### DIFF
--- a/libuvccamera/build.gradle
+++ b/libuvccamera/build.gradle
@@ -44,6 +44,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'consumer-rules.pro'
         }
     }
     externalNativeBuild {

--- a/libuvccamera/consumer-rules.pro
+++ b/libuvccamera/consumer-rules.pro
@@ -1,0 +1,6 @@
+################libuvccamera##################
+-keep class com.herohan.uvcapp.** { *; }
+-keep class com.serenegiant.usb.** { *; }
+-keepclassmembers class * implements com.serenegiant.usb.IButtonCallback {*;}
+-keepclassmembers class * implements com.serenegiant.usb.IFrameCallback {*;}
+-keepclassmembers class * implements com.serenegiant.usb.IStatusCallback {*;}


### PR DESCRIPTION
Hey, first of all, thank you for your work 👏 

## Issue description

Even though it's written in the README that the obfuscation rules for R8 are included automatically: 
https://github.com/shiyinghan/UVCAndroid/blob/14a0ac95944702e3361ff28a093c72436e0f950a/README.md?plain=1#L25-L28

It's actually not correct, the rules are not automatically included in the build, and R8 can't pick up something that's not included.

## Solution

We need to specify consumer proguard files. 

`proguard-rules.pro` specify rules for Proguard how to produce a release build for the library, i.e. the `.aar` file that is later downloaded by the users. However, Consumer ProGuard rules are used for specifying how a library's code should be treated when it is included in an app using that library. 

While a public library should not obfuscate much in the release build (and an open source library arguably shouldn't obfuscate anything at all), this is not true for the apps that use the library. The final apks don't need to preserve public library APIs, they just should minify/obfuscate as much as possible without breaking the functionality.

See more detailed answer on stackoverflow: https://stackoverflow.com/a/60862591 .

## Further steps

I just copied the existing proguard rules into the `consumer-rules.pro`. However, the rules should very likely be more aggressive by the reasons explained above. We need to just save the classes that are accessed via reflection or from JNI.

However, it still makes sense to merge this PR as it is, because otherwise the library is not working when used in the obfuscated apks.