### PR TITLE
Always call callback when taking picture

### DIFF
--- a/libuvccamera/src/main/java/com/herohan/uvcapp/CameraConnectionService.java
+++ b/libuvccamera/src/main/java/com/herohan/uvcapp/CameraConnectionService.java
@@ -1,5 +1,7 @@
 package com.herohan.uvcapp;
 
+import static com.herohan.uvcapp.ImageCapture.ERROR_INVALID_CAMERA;
+
 import android.hardware.usb.UsbDevice;
 import android.os.Handler;
 import android.os.HandlerThread;
@@ -371,6 +373,9 @@ class CameraConnectionService {
             final CameraInternal cameraInternal = getCamera(device);
             if (cameraInternal != null) {
                 cameraInternal.takePicture(options, callback);
+            } else {
+                String message = "Camera not available";
+                callback.onError(ERROR_INVALID_CAMERA, message, new IllegalStateException(message));
             }
         }
 

--- a/libuvccamera/src/main/java/com/herohan/uvcapp/CameraHelper.java
+++ b/libuvccamera/src/main/java/com/herohan/uvcapp/CameraHelper.java
@@ -1,5 +1,8 @@
 package com.herohan.uvcapp;
 
+import static com.herohan.uvcapp.ImageCapture.ERROR_CAMERA_CLOSED;
+import static com.herohan.uvcapp.ImageCapture.ERROR_UNKNOWN;
+
 import android.content.Context;
 import android.graphics.SurfaceTexture;
 import android.hardware.usb.UsbDevice;
@@ -332,7 +335,15 @@ public class CameraHelper implements ICameraHelper {
                     mService.takePicture(mUsbDevice, options, callback);
                 } catch (final Exception e) {
                     if (DEBUG) Log.e(TAG, "takePicture", e);
+                    String message = e.getMessage();
+                    if (message == null) {
+                        message = "takePicture failed with an unknown exception";
+                    }
+                    callback.onError(ERROR_UNKNOWN, message, e);
                 }
+            } else {
+                String message = "Camera is released";
+                callback.onError(ERROR_CAMERA_CLOSED, message, new IllegalStateException(message));
             }
         });
     }

--- a/libuvccamera/src/main/java/com/herohan/uvcapp/CameraRendererHolder.java
+++ b/libuvccamera/src/main/java/com/herohan/uvcapp/CameraRendererHolder.java
@@ -56,8 +56,12 @@ class CameraRendererHolder extends RendererHolder implements ICameraRendererHold
     public void captureImage(OnImageCapturedCallback callback) {
         mRendererHandler.post(() -> {
             // Capture still image
-            ImageRawData data = mCaptureHolder.captureImageRawData();
-            callback.onCaptureSuccess(data);
+            try {
+                ImageRawData data = mCaptureHolder.captureImageRawData();
+                callback.onCaptureSuccess(data);
+            } catch (Exception e) {
+                callback.onError(e);
+            }
         });
     }
 

--- a/libuvccamera/src/main/java/com/herohan/uvcapp/ICameraRendererHolder.java
+++ b/libuvccamera/src/main/java/com/herohan/uvcapp/ICameraRendererHolder.java
@@ -12,5 +12,7 @@ interface ICameraRendererHolder extends IRendererHolder {
 
     interface OnImageCapturedCallback{
         void onCaptureSuccess(ImageRawData image);
+
+        void onError(Exception e);
     }
 }


### PR DESCRIPTION
### Issue description

When calling `CameraHelper.takePicture(...)`, there are several cases when error is not reported to the provided callback.

### Use case

Applications shows a dialog while taking picture is in progress.
This dialog is dismissed when picture is taken, or replaced with a closable error dialog when error occurs.
When camera get disconnected right before we call `takePicture()`, callback is not called at all and the dialog will never be dismissed.

### Solution

Handle every cases when taking picture and call `callback.onError()` when getting image is not possible or failed.

### Notes

The fix touches just one internal interface `ICameraRendererHolder.java`, so it brings no braking changes to any user of the library.

---

Thank you @shiyinghan for maintaining the library!