### PR TITLE
Fix the bug of not opening the device when re-attached

### DIFF
--- a/libuvccamera/src/main/java/com/herohan/uvcapp/CameraHelper.java
+++ b/libuvccamera/src/main/java/com/herohan/uvcapp/CameraHelper.java
@@ -588,6 +588,9 @@ public class CameraHelper implements ICameraHelper {
         @Override
         public void onAttach(UsbDevice device) {
             if (DEBUG) Log.d(TAG, "onAttach:");
+            synchronized (mDetachedDeviceMap) {
+                mDetachedDeviceMap.remove(device);
+            }
             mMainHandler.post(() -> mCallback.onAttach(device));
         }
 


### PR DESCRIPTION
This bug was caused by `mDetachedDeviceMap` recording all the devices that have been previously detached, thus preventing the same USB device from being opened upon re-attaching.