### PR TITLE
Update device_filter.xml

### DIFF
--- a/libuvccamera/src/main/res/xml/device_filter.xml
+++ b/libuvccamera/src/main/res/xml/device_filter.xml
@@ -24,10 +24,8 @@
   -->
 
 <usb>
-<!--	<usb-device class="239" subclass="2" />	&lt;!&ndash; all device of UVC &ndash;&gt;-->
 	<!-- Interface Descriptors Base Class 0Eh (Video) -->
 	<usb-device class="14"/>
-	<!--	<usb-device product-id="5120" vendor-id="1409" />-->
-	<!-- IDS Imaging Development Systems GmbH -->
-	<usb-device vendor-id="1409" />
+	<!-- Interface Descriptors Base Class EFh (Miscellaneous), i.e. all other UVC devices -->
+	<usb-device class="239" subclass="2" />
 </usb>


### PR DESCRIPTION
Remove unused & irrelevant usb-device descriptors, because only the video class and misc class are needed.

> If any developer needs to limit their app's interest to specific vendor ID & product ID, then they could list out those descriptors in the format of `<usb-device product-id="6489" vendor-id="8964" />`.