### PR TITLE
Target SDK 34 (Android 14)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
     defaultConfig {
         applicationId "com.herohan.uvcapp"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 34
         versionCode 3
         versionName "1.0.2"
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ task clean(type: Delete) {
 
 ext {
 	versionCompiler = 31
-	versionTarget = 27
+	versionTarget = 34
 	versionMin = 19
 
 	javaSourceCompatibility = JavaVersion.VERSION_1_8

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -8,7 +8,7 @@ android {
     defaultConfig {
         applicationId "com.herohan.uvcdemo"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 34
         versionCode 2
         versionName "1.0.1"
 

--- a/libuvccamera/build.gradle
+++ b/libuvccamera/build.gradle
@@ -63,6 +63,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
+    implementation 'androidx.core:core:1.13.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.annotation:annotation:1.3.0'

--- a/libuvccamera/build.gradle
+++ b/libuvccamera/build.gradle
@@ -47,6 +47,9 @@ android {
             consumerProguardFiles 'consumer-rules.pro'
         }
     }
+    buildFeatures {
+        buildConfig true
+    }
     externalNativeBuild {
         ndkBuild {
             path file('src/main/jni/Android.mk')

--- a/libuvccamera/src/main/java/com/serenegiant/usb/USBMonitor.java
+++ b/libuvccamera/src/main/java/com/serenegiant/usb/USBMonitor.java
@@ -217,13 +217,11 @@ public final class USBMonitor {
             if (DEBUG) Log.i(TAG, "register:");
             final Context context = mWeakContext.get();
             if (context != null) {
-                int flags = 0;
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    // Up until Build.VERSION_CODES.R, PendingIntents are assumed to be mutable by default, unless FLAG_IMMUTABLE is set.
-                    // Starting with Build.VERSION_CODES.S, it will be required to explicitly specify the mutability of PendingIntents on creation with either (@link #FLAG_IMMUTABLE} or FLAG_MUTABLE.
-                    flags = PendingIntent.FLAG_MUTABLE;
-                }
-                mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), flags);
+                mPermissionIntent = PendingIntent.getBroadcast(
+                        context,
+                        0,
+                        new Intent(ACTION_USB_PERMISSION),
+                        PendingIntent.FLAG_IMMUTABLE);
                 final IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
                 // ACTION_USB_DEVICE_ATTACHED never comes on some devices so it should not be added here
                 filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);

--- a/libuvccamera/src/main/java/com/serenegiant/usb/USBMonitor.java
+++ b/libuvccamera/src/main/java/com/serenegiant/usb/USBMonitor.java
@@ -50,6 +50,8 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.util.SparseArray;
 
+import androidx.core.content.ContextCompat;
+
 import com.serenegiant.utils.HandlerThreadHandler;
 import com.serenegiant.uvccamera.BuildConfig;
 
@@ -225,7 +227,7 @@ public final class USBMonitor {
                 final IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
                 // ACTION_USB_DEVICE_ATTACHED never comes on some devices so it should not be added here
                 filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
-                context.registerReceiver(mUsbReceiver, filter);
+                ContextCompat.registerReceiver(context, mUsbReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
             }
             // start connection check
             mDetectedDeviceKeys.clear();


### PR DESCRIPTION
In addition to updating the target SDK versions, also updates USBMonitor to always use the FLAG_IMMUTABLE when attempting to request device permissions.

This fixes an issue when using the library with apps targeting 34, where CameraHelper would be unable to open devices due to USBMonitor attempting to build the device permissions intent using FLAG_MUTABLE. This is no longer allowed, and will throw a RemoteException with the message:

 > Targeting U+ (version 34 and above) disallows creating or retrieving a PendingIntent with FLAG_MUTABLE, an implicit Intent within and without FLAG_NO_CREATE and FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT for security reasons. To retrieve an already existing PendingIntent, use FLAG_NO_CREATE, however, to create a new PendingIntent with an implicit Intent use FLAG_IMMUTABLE.

Camera device attach/detach events were not being received due to a SecurityException:

> One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts