### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/libuvccamera/src/main/jni/libjpeg-turbo/jdpostct.c
+++ b/libuvccamera/src/main/jni/libjpeg-turbo/jdpostct.c
@@ -137,6 +137,11 @@ post_process_1pass(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
   my_post_ptr post = (my_post_ptr)cinfo->post;
   JDIMENSION num_rows, max_rows;
 
+  /* read_and_discard_scanlines may call it with rows "available", but no buffer */
+  if (output_buf == NULL) {
+    return;
+  }
+
   /* Fill the buffer, but not more than what we can dump out in one go. */
   /* Note we rely on the upsampler to detect bottom of image. */
   max_rows = out_rows_avail - *out_row_ctr;

--- a/libuvccamera/src/main/jni/libjpeg-turbo/jerror.h
+++ b/libuvccamera/src/main/jni/libjpeg-turbo/jerror.h
@@ -206,6 +206,7 @@ JMESSAGE(JERR_NO_ARITH_TABLE, "Arithmetic table 0x%02x was not defined")
 JMESSAGE(JWRN_ARITH_BAD_CODE, "Corrupt JPEG data: bad arithmetic code")
 #endif
 #endif
+JMESSAGE(JERR_BAD_PARAM, "Bogus parameter")
 JMESSAGE(JWRN_BOGUS_ICC, "Corrupt JPEG data: bad ICC marker")
 #if JPEG_LIB_VERSION < 70
 JMESSAGE(JERR_BAD_DROP_SAMPLING,

--- a/libuvccamera/src/main/jni/libjpeg-turbo/jquant1.c
+++ b/libuvccamera/src/main/jni/libjpeg-turbo/jquant1.c
@@ -473,6 +473,10 @@ color_quantize(j_decompress_ptr cinfo, JSAMPARRAY input_buf,
   JDIMENSION width = cinfo->output_width;
   register int nc = cinfo->out_color_components;
 
+  if (output_buf == NULL && num_rows) {
+    ERREXIT(cinfo, JERR_BAD_PARAM);
+  }
+
   for (row = 0; row < num_rows; row++) {
     ptrin = input_buf[row];
     ptrout = output_buf[row];


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in libuvccamera/src/main/jni/libjpeg-turbo/jquant1.c which was cloned from libjpeg-turbo/libjpeg-turbo but did not receive the security patch applied in libjpeg-turbo/libjpeg-turbo. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2017-15232.

### Proposed Fix
Apply the same patch as the one in libjpeg-turbo/libjpeg-turbo to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2017-15232
https://github.com/madler/zlib/commit/9aaec95e82117c1cb0f9624264c3618fc380cecb