### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/libuvccamera/src/main/jni/rapidjson/thirdparty/yajl/src/yajl_tree.c
+++ b/libuvccamera/src/main/jni/rapidjson/thirdparty/yajl/src/yajl_tree.c
@@ -143,7 +143,7 @@ static yajl_val context_pop(context_t *ctx)
     ctx->stack = stack->next;
 
     v = stack->value;
-
+    free (stack->key);
     free (stack);
 
     return (v);
@@ -444,7 +444,14 @@ yajl_val yajl_tree_parse (const char *input,
                                         (const unsigned char *) input,
                                         strlen(input)));
         }
+        while(ctx.stack != NULL) {
+             yajl_val v = context_pop(&ctx);
+             yajl_tree_free(v);
+        }
         yajl_free (handle);
+        //If the requested memory is not released in time, it will cause memory leakage
+        if(ctx.root)
+            yajl_tree_free(ctx.root);
         return NULL;
     }
 


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in libuvccamera/src/main/jni/rapidjson/thirdparty/yajl/src/yajl_tree.c which was cloned from likema/yajl but did not receive the security patch applied in likema/yajl. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2023-33460.

### Proposed Fix
Apply the same patch as the one in likema/yajl to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2023-33460
https://github.com/likema/yajl/commit/31531a6e6b5641398237ce15b7e62da02d975fc6