### PR TITLE
refactor(libuvccamera): 移除hutool依赖并优化文件工具类

### DIFF
--- a/libuvccamera/build.gradle
+++ b/libuvccamera/build.gradle
@@ -71,7 +71,6 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.annotation:annotation:1.8.0'
-    implementation 'cn.hutool:hutool-core:5.8.35'
 }
 
 ext {

--- a/libuvccamera/src/main/java/com/serenegiant/utils/FileUtils.java
+++ b/libuvccamera/src/main/java/com/serenegiant/utils/FileUtils.java
@@ -8,6 +8,7 @@ import android.os.Build;
 import android.os.Environment;
 import android.provider.MediaStore;
 import android.text.TextUtils;
+import android.webkit.MimeTypeMap;
 
 import androidx.annotation.NonNull;
 
@@ -19,8 +20,6 @@ import java.io.InputStreamReader;
 import java.text.SimpleDateFormat;
 import java.util.GregorianCalendar;
 import java.util.Locale;
-
-import cn.hutool.core.io.FileUtil;
 
 public class FileUtils {
     private static final String TAG = FileUtils.class.getSimpleName();
@@ -54,7 +53,13 @@ public class FileUtils {
         if (!TextUtils.isEmpty(prefix)) {
             fileName = prefix + fileName;
         }
-        String mimeType = FileUtil.getMimeType(ext);
+        
+        String extension = "";
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot > 0 && lastDot < fileName.length() - 1) {
+            extension = fileName.substring(lastDot + 1).toLowerCase(Locale.getDefault());
+        }
+        String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
 
         // Add a specific media item.
         ContentResolver resolver = context.getContentResolver();


### PR DESCRIPTION
移除了对cn.hutool:hutool-core的依赖，改用Android原生的MimeTypeMap来获取 MIME类型，减少外部依赖，提高代码的独立性。

在我的项目中打包的时候会出现R8错误，查看报错是hutool-core的包里的Img/ImgUtil模块包含java.awt，在 Android 上不能直接使用，需要一些忽略配置。我查看源代码，hutool只是用于获取mimeType，使用android原生方法获取，替换